### PR TITLE
Improvment on method cubage_total under the class WC_Correios_Package.

### DIFF
--- a/includes/class-wc-correios-package.php
+++ b/includes/class-wc-correios-package.php
@@ -98,16 +98,11 @@ class WC_Correios_Package {
 	 */
 	protected function cubage_total( $height, $width, $length ) {
 		// Sets the cubage of all products.
-		$all         = array();
 		$total       = 0;
 		$total_items = count( $height );
 
 		for ( $i = 0; $i < $total_items; $i++ ) {
-			$all[ $i ] = $height[ $i ] * $width[ $i ] * $length[ $i ];
-		}
-
-		foreach ( $all as $value ) {
-			$total += $value;
+			$total += $height[ $i ] * $width[ $i ] * $length[ $i ];
 		}
 
 		return $total;


### PR DESCRIPTION
The method `cubage_total` under the class `WC_Correios_Package` have 2 loops, one regular for that append a value into an array, and another that walks in the new array and sum each value. The second `foreach` seems to be unnecessary so we could reduce the code.