### PR TITLE
added hook to detect completed webservice request

### DIFF
--- a/includes/class-wc-correios-webservice.php
+++ b/includes/class-wc-correios-webservice.php
@@ -550,6 +550,8 @@ class WC_Correios_Webservice {
 
 		// Gets the WebServices response.
 		$response = wp_safe_remote_get( esc_url_raw( $url ), array( 'timeout' => 30 ) );
+		
+		do_action( 'woocommerce_correios_webservice_request_finished', $response, $args );
 
 		if ( is_wp_error( $response ) ) {
 			if ( 'yes' === $this->debug ) {


### PR DESCRIPTION
Adicionei um hook para detectar que uma requisição foi feita ao webservice do correios. Precisei disso para saber se a requisição deu algum erro. Pois recentemente tive que desenvolver uma solução para um cliente que quando houvesse algum erro aparecesse um método *fallback* para evitar que aconteça vendas sem frete (como estava acontecendo devido a erros no webservice do correios). Porém esse método *fallback* não deveria aparecer quando o erro fosse cep inválido, devido a ser um erro do usuário que digitou errado.