### PR TITLE
Fix WC_Correios_Package swapping Height with Lenght

### DIFF
--- a/includes/class-wc-correios-package.php
+++ b/includes/class-wc-correios-package.php
@@ -53,9 +53,9 @@ class WC_Correios_Package {
 
 			if ( $qty > 0 && $product->needs_shipping() ) {
 
-				$_height = wc_get_dimension( (float) $product->get_length(), 'cm' );
+				$_height = wc_get_dimension( (float) $product->get_height(), 'cm' );
 				$_width  = wc_get_dimension( (float) $product->get_width(), 'cm' );
-				$_length = wc_get_dimension( (float) $product->get_height(), 'cm' );
+				$_length = wc_get_dimension( (float) $product->get_length(), 'cm' );
 				$_weight = wc_get_weight( (float) $product->get_weight(), 'kg' );
 
 				$height[ $count ] = $_height;


### PR DESCRIPTION
O método get_package_data() da classe WC_Correios_Package, troca Altura por Comprimento:

```
$_height = wc_get_dimension( (float) $product->get_length(), 'cm' );
$_length = wc_get_dimension( (float) $product->get_height(), 'cm' );
```

Analisando o código, essa troca passa despercebida, e estas dimensões não são destrocadas nem no método, nem na classe.

O pull-request simplesmente atribui as dimensões corretas ao Package.