### PR TITLE
Update Impresso Normal, RM and RN costs

### DIFF
--- a/includes/abstracts/class-wc-correios-shipping-impresso.php
+++ b/includes/abstracts/class-wc-correios-shipping-impresso.php
@@ -21,42 +21,42 @@ abstract class WC_Correios_Shipping_Impresso extends WC_Correios_Shipping_Carta 
 	/**
 	 * National Registry cost.
 	 *
-	 * Cost based in 31/07/2017 from:
+	 * Cost based in 01/08/2018 from:
 	 * http://www.correios.com.br/para-voce/consultas-e-solicitacoes/precos-e-prazos/servicos-adicionais-nacionais
 	 *
 	 * @var float
 	 */
-	protected $national_registry_cost = 5.00;
+	protected $national_registry_cost = 5.75;
 
 	/**
 	 * Reasonable Registry cost.
 	 *
-	 * Cost based in 31/07/2017 from:
+	 * Cost based in 01/08/2018 from:
 	 * http://www.correios.com.br/para-voce/consultas-e-solicitacoes/precos-e-prazos/servicos-adicionais-nacionais
 	 *
 	 * @var float
 	 */
-	protected $reasonable_registry_cost = 2.50;
+	protected $reasonable_registry_cost = 2.90;
 
 	/**
 	 * Receipt Notice cost.
 	 *
-	 * Cost based in 31/07/2017 from:
+	 * Cost based in 01/08/2018 from:
 	 * https://www.correios.com.br/para-voce/consultas-e-solicitacoes/precos-e-prazos/servicos-adicionais-nacionais
 	 *
 	 * @var float
 	 */
-	protected $receipt_notice_cost = 5.00;
+	protected $receipt_notice_cost = 5.75;
 
 	/**
 	 * Own Hands cost.
 	 *
-	 * Cost based in 31/07/2017 from:
+	 * Cost based in 01/08/2018 from:
 	 * https://www.correios.com.br/para-voce/consultas-e-solicitacoes/precos-e-prazos/servicos-adicionais-nacionais
 	 *
 	 * @var float
 	 */
-	protected $own_hands_cost = 5.90;
+	protected $own_hands_cost = 6.80;
 
 	/**
 	 * Weight limit for reasonable registry.

--- a/includes/shipping/class-wc-correios-shipping-impresso-normal.php
+++ b/includes/shipping/class-wc-correios-shipping-impresso-normal.php
@@ -76,7 +76,7 @@ class WC_Correios_Shipping_Impresso_Normal extends WC_Correios_Shipping_Impresso
 			'100' => 2.15,
 			'150' => 2.60,
 			'200' => 3.10,
-			'250' => 3.50,
+			'250' => 3.60,
 			'300' => 4.05,
 			'350' => 4.50,
 			'400' => 5.05,


### PR DESCRIPTION
Atualizei os custos de Registro Módico e Registro Nacional que estavam antigos. Também arrumei um dos custos de Impresso Normal que estava errado.

Pelo que sei o limite de peso do Registro Módico não é mais 500g, mas não encontrei essa informação no site dos Correios para atualizar.