### PR TITLE
Fix tracking email to support bulk sending

### DIFF
--- a/includes/emails/class-wc-correios-tracking-email.php
+++ b/includes/emails/class-wc-correios-tracking-email.php
@@ -171,11 +171,11 @@ class WC_Correios_Tracking_Email extends WC_Email {
 				$this->recipient = $order->billing_email;
 			}
 
-			$this->find[]    = '{order_number}';
-			$this->replace[] = $order->get_order_number();
+			$this->find['order_number']    = '{order_number}';
+			$this->replace['order_number'] = $order->get_order_number();
 
-			$this->find[]    = '{date}';
-			$this->replace[] = date_i18n( wc_date_format(), time() );
+			$this->find['date']    = '{date}';
+			$this->replace['date'] = date_i18n( wc_date_format(), time() );
 
 			if ( empty( $tracking_code ) ) {
 				$tracking_codes = wc_correios_get_tracking_codes( $order );
@@ -183,8 +183,8 @@ class WC_Correios_Tracking_Email extends WC_Email {
 				$tracking_codes = array( $tracking_code );
 			}
 
-			$this->find[]    = '{tracking_code}';
-			$this->replace[] = $this->get_tracking_codes( $tracking_codes );
+			$this->find['tracking_code']    = '{tracking_code}';
+			$this->replace['tracking_code'] = $this->get_tracking_codes( $tracking_codes );
 		}
 
 		if ( ! $this->get_recipient() ) {


### PR DESCRIPTION
Tive um problema ao iterar sobre um conjunto de pedidos e, para cada um deles, chamar a wc_correios_update_tracking_code(). O código de rastreamento era associado corretamente a cada pedido. No entanto, em vez de cada usuário receber o seu código por e-mail, todos recebiam um e-mail com o número de pedido e o código de rastreamento do primeiro pedido do loop. As outras informações do e-mail (a tabela com detalhes do pedido, por exemplo) estavam certas.

Esse commit resolve isso. Não tenho certeza se é a solução ideal, mas para mim funcionou.