### PR TITLE
Updating Email placeholders.

### DIFF
--- a/includes/emails/class-wc-correios-tracking-email.php
+++ b/includes/emails/class-wc-correios-tracking-email.php
@@ -171,20 +171,15 @@ class WC_Correios_Tracking_Email extends WC_Email {
 				$this->recipient = $order->billing_email;
 			}
 
-			$this->find[]    = '{order_number}';
-			$this->replace[] = $order->get_order_number();
-
-			$this->find[]    = '{date}';
-			$this->replace[] = date_i18n( wc_date_format(), time() );
-
 			if ( empty( $tracking_code ) ) {
 				$tracking_codes = wc_correios_get_tracking_codes( $order );
 			} else {
 				$tracking_codes = array( $tracking_code );
 			}
 
-			$this->find[]    = '{tracking_code}';
-			$this->replace[] = $this->get_tracking_codes( $tracking_codes );
+			$this->placeholders['{order_number}']  = $order->get_order_number();
+			$this->placeholders['{date}']          = date_i18n( wc_date_format(), time() );
+			$this->placeholders['{tracking_code}'] = $this->get_tracking_codes( $tracking_codes );
 		}
 
 		if ( ! $this->get_recipient() ) {


### PR DESCRIPTION
Atualizei para a nova variável que armazena os placeholders find/replace dos e-mails.

A forma anterior causava também um problema ao executar adição em massa de códigos de rastreio.

Para testar basta executar o código abaixo:

```
wc_correios_update_tracking_code( $order1, '123AAAA' );
wc_correios_update_tracking_code( $order2 '456BAAA' );
```

Os dois e-mais terão o mesmo código de rastreio e título de e-mail.