### PR TITLE
Valor mínimo atualizado para a nova polícia comercial

### DIFF
--- a/includes/abstracts/class-wc-correios-shipping.php
+++ b/includes/abstracts/class-wc-correios-shipping.php
@@ -33,6 +33,13 @@ abstract class WC_Correios_Shipping extends WC_Shipping_Method {
 	protected $corporate_code = '';
 
 	/**
+	 * Minimum value to ignore the flag of declared value.
+	 * 
+	 * @var float
+	 */
+	protected $min_declared_value = 20.5;
+
+	/**
 	 * Initialize the Correios shipping method.
 	 *
 	 * @param int $instance_id Shipping zone instance ID.

--- a/includes/shipping/class-wc-correios-shipping-pac.php
+++ b/includes/shipping/class-wc-correios-shipping-pac.php
@@ -52,7 +52,7 @@ class WC_Correios_Shipping_PAC extends WC_Correios_Shipping {
 	 * @return float
 	 */
 	protected function get_declared_value( $package ) {
-		if ( 18 >= $package['contents_cost'] ) {
+		if ( $this->min_declared_value >= $package['contents_cost'] ) {
 			return 0;
 		}
 

--- a/includes/shipping/class-wc-correios-shipping-sedex-10-envelope.php
+++ b/includes/shipping/class-wc-correios-shipping-sedex-10-envelope.php
@@ -44,7 +44,7 @@ class WC_Correios_Shipping_SEDEX_10_Envelope extends WC_Correios_Shipping {
 	 * @return float
 	 */
 	protected function get_declared_value( $package ) {
-		if ( 18 >= $package['contents_cost'] ) {
+		if ( $this->min_declared_value >= $package['contents_cost'] ) {
 			return 0;
 		}
 

--- a/includes/shipping/class-wc-correios-shipping-sedex-10-pacote.php
+++ b/includes/shipping/class-wc-correios-shipping-sedex-10-pacote.php
@@ -44,7 +44,7 @@ class WC_Correios_Shipping_SEDEX_10_Pacote extends WC_Correios_Shipping {
 	 * @return float
 	 */
 	protected function get_declared_value( $package ) {
-		if ( 18 >= $package['contents_cost'] ) {
+		if ( $this->min_declared_value >= $package['contents_cost'] ) {
 			return 0;
 		}
 

--- a/includes/shipping/class-wc-correios-shipping-sedex-12.php
+++ b/includes/shipping/class-wc-correios-shipping-sedex-12.php
@@ -44,7 +44,7 @@ class WC_Correios_Shipping_SEDEX_12 extends WC_Correios_Shipping {
 	 * @return float
 	 */
 	protected function get_declared_value( $package ) {
-		if ( 18 >= $package['contents_cost'] ) {
+		if ( $this->min_declared_value >= $package['contents_cost'] ) {
 			return 0;
 		}
 

--- a/includes/shipping/class-wc-correios-shipping-sedex-hoje.php
+++ b/includes/shipping/class-wc-correios-shipping-sedex-hoje.php
@@ -44,7 +44,7 @@ class WC_Correios_Shipping_SEDEX_Hoje extends WC_Correios_Shipping {
 	 * @return float
 	 */
 	protected function get_declared_value( $package ) {
-		if ( 18 >= $package['contents_cost'] ) {
+		if ( $this->min_declared_value >= $package['contents_cost'] ) {
 			return 0;
 		}
 

--- a/includes/shipping/class-wc-correios-shipping-sedex.php
+++ b/includes/shipping/class-wc-correios-shipping-sedex.php
@@ -52,7 +52,7 @@ class WC_Correios_Shipping_SEDEX extends WC_Correios_Shipping {
 	 * @return float
 	 */
 	protected function get_declared_value( $package ) {
-		if ( 18 >= $package['contents_cost'] ) {
+		if ( $this->min_declared_value >= $package['contents_cost'] ) {
 			return 0;
 		}
 


### PR DESCRIPTION
Os correios atualizaram a polícia comercial deles, vai entrar em vigor em 01/2021 porém algumas chamadas já estão retornando com erro principalmente em relação ao valor mínimo declarado.

Neste PR eu simplesmente joguei a responsabilidade de saber o valor mínimo atual para a classe `WC_Correios_Shipping` e os sub produtos simplesmente a utilizam para verificar se declaram ou não o valor declarado na chamada.

Esse PR resolve: #191 e #196 