### PR TITLE
improve wc_correios_get_estimating_delivery

### DIFF
--- a/includes/class-wc-correios-cart.php
+++ b/includes/class-wc-correios-cart.php
@@ -30,9 +30,9 @@ class WC_Correios_Cart {
 		$meta_data = $shipping_method->get_meta_data();
 		$total     = isset( $meta_data['_delivery_forecast'] ) ? intval( $meta_data['_delivery_forecast'] ) : 0;
 
-		if ( $total ) {
+		if ( $total > 0 ) {
 			/* translators: %d: days to delivery */
-			echo '<p><small>' . esc_html( sprintf( _n( 'Delivery within %d working day', 'Delivery within %d working days', $total, 'woocommerce-correios' ), $total ) ) . '</small></p>';
+			echo '<p><small>' . esc_html( wc_correios_get_estimating_delivery( null, $total ) ) . '</small></p>';
 		}
 	}
 }

--- a/includes/wc-correios-functions.php
+++ b/includes/wc-correios-functions.php
@@ -71,7 +71,8 @@ function wc_correios_get_estimating_delivery( $name, $days, $additional_days = 0
 
 	if ( $total > 0 ) {
 		/* translators: %d: days to delivery */
-		$name .= ' (' . sprintf( _n( 'Delivery within %d working day', 'Delivery within %d working days', $total, 'woocommerce-correios' ), $total ) . ')';
+		$estimating = sprintf( _n( 'Delivery within %d working day', 'Delivery within %d working days', $total, 'woocommerce-correios' ), $total );
+		$name = $name ? $name . " ($estimating)" : $estimating;
 	}
 
 	return apply_filters( 'woocommerce_correios_get_estimating_delivery', $name, $days, $additional_days );


### PR DESCRIPTION
## O que mudou

A `wc_correios_get_estimating_delivery` continua funcionando da mesma maneira para evitar uma breaking change desnecessário (em outros plugins ou códigos que possam estar usando-a). Porém, se passar o primeiro argumento com algum valor "falsy", vai retornar somente a estimativa de entrega (sem os parenteses em volta).

## Motivação

A `wc_correios_get_estimating_delivery` função é muito útil para aproveitar o texto do plugin em outros plugins que integram com ele. Porém, é sempre necessário passar um argumento `$name` e a estimativa de entrega entre volta dentro de parenteses.